### PR TITLE
Lowercase windows.h to support mingw@linux

### DIFF
--- a/include/co/atomic.h
+++ b/include/co/atomic.h
@@ -9,7 +9,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 #ifdef InterlockedIncrement64
 #define _InterlockedIncrement64    InterlockedIncrement64

--- a/include/co/err.h
+++ b/include/co/err.h
@@ -4,7 +4,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace err {
 

--- a/include/co/thread.h
+++ b/include/co/thread.h
@@ -10,7 +10,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace co {
 namespace xx {

--- a/src/fs_win.cc
+++ b/src/fs_win.cc
@@ -7,7 +7,7 @@
 #ifdef _MSC_VER
 #pragma warning (disable:4800)
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace fs {
 

--- a/src/os_win.cc
+++ b/src/os_win.cc
@@ -7,7 +7,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace os {
 

--- a/src/time_win.cc
+++ b/src/time_win.cc
@@ -7,7 +7,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace now {
 namespace _Mono {

--- a/src/unitest.cc
+++ b/src/unitest.cc
@@ -12,7 +12,7 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 DEF_bool(a, false, ".Run all tests if true");


### PR DESCRIPTION
Linux is case sensitive, cross-compilation to windows with mingw would likely fail due to inclusion of `Windows.h` instead of `windows.h`