### PR TITLE
"Interrupted system call" is not an error log

### DIFF
--- a/src/co/scheduler.cc
+++ b/src/co/scheduler.cc
@@ -106,7 +106,9 @@ void SchedulerImpl::loop() {
         if (_stop) break;
 
         if (unlikely(n == -1)) {
-            ELOG << "epoll wait error: " << co::strerror();
+            if (errno != EINTR) {
+                ELOG << "epoll wait error: " << co::strerror();
+            }
             continue;
         }
 


### PR DESCRIPTION
EINTR is easy to appear when you interrupt debugging, but it is not an error